### PR TITLE
Fix timer restart in Shadowboxing activity

### DIFF
--- a/Kotlin-code.txt
+++ b/Kotlin-code.txt
@@ -524,6 +524,7 @@ class ShadowboxingTimerActivity : AppCompatActivity() {
                 }
                 
                 override fun onFinish() {
+                    isRunning = false
                     playBeep()
                     if (isWorking) {
                         // Work period finished, start rest


### PR DESCRIPTION
## Summary
- fix auto-restart in `ShadowboxingTimerActivity` by resetting `isRunning` when a timer finishes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68457912a858832a973d3152d8d2abb0