### PR TITLE
Add workout tracking utilities

### DIFF
--- a/src/main/kotlin/com/boxandabs/app/CalendarUtils.kt
+++ b/src/main/kotlin/com/boxandabs/app/CalendarUtils.kt
@@ -30,3 +30,29 @@ fun generateCalendarDays(now: Calendar = Calendar.getInstance()): List<CalendarD
     }
     return days
 }
+
+/**
+ * Counts how many days in the given list are marked with status "done".
+ */
+fun countCompletedDays(days: List<CalendarDay>): Int {
+    return days.count { it.status == "done" }
+}
+
+/**
+ * Calculates the longest streak of consecutive days with status "done".
+ */
+fun longestStreak(days: List<CalendarDay>): Int {
+    var maxStreak = 0
+    var currentStreak = 0
+    for (day in days) {
+        if (day.status == "done") {
+            currentStreak++
+            if (currentStreak > maxStreak) {
+                maxStreak = currentStreak
+            }
+        } else {
+            currentStreak = 0
+        }
+    }
+    return maxStreak
+}

--- a/src/test/kotlin/com/boxandabs/app/CalendarUtilsTest.kt
+++ b/src/test/kotlin/com/boxandabs/app/CalendarUtilsTest.kt
@@ -22,4 +22,31 @@ class CalendarUtilsTest {
         assertEquals("today", days[todayIndex].status)
         assertTrue(days[todayIndex].isCurrentMonth)
     }
+
+    @Test
+    fun testCountCompletedDays() {
+        val days = listOf(
+            CalendarDay(1, "done", true),
+            CalendarDay(2, "done", true),
+            CalendarDay(3, "skipped", true),
+            CalendarDay(4, "done", true)
+        )
+
+        assertEquals(3, countCompletedDays(days))
+    }
+
+    @Test
+    fun testLongestStreak() {
+        val days = listOf(
+            CalendarDay(1, "done", true),
+            CalendarDay(2, "done", true),
+            CalendarDay(3, "skipped", true),
+            CalendarDay(4, "done", true),
+            CalendarDay(5, "done", true),
+            CalendarDay(6, "done", true),
+            CalendarDay(7, "rest", true)
+        )
+
+        assertEquals(3, longestStreak(days))
+    }
 }


### PR DESCRIPTION
## Summary
- add new functions `countCompletedDays` and `longestStreak`
- test the new workout tracking utilities

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6846090fe860832a92c5ff6d217a615d